### PR TITLE
Use Length attribute for regex matching so we dont read the hole file into the memory

### DIFF
--- a/src/main/java/net/sf/jmimemagic/MagicMatcher.java
+++ b/src/main/java/net/sf/jmimemagic/MagicMatcher.java
@@ -186,7 +186,10 @@ public class MagicMatcher implements Cloneable
             } else if (type.equals("string")) {
                 length = match.getTest().capacity();
             } else if (type.equals("regex")) {
-                length = (int) file.length() - offset;
+                
+                
+                final int matchLength = match.getLength();
+                length = (matchLength == 0) ? (int) file.length() - offset : matchLength;
 
                 if (length < 0) {
                     length = 0;


### PR DESCRIPTION
I started adding matching movie files (mp4) etc and those are huge, so I dont want them in the memory :)
