### PR TITLE
Better HTML detection + custom magic.xml

### DIFF
--- a/src/main/java/net/sf/jmimemagic/Magic.java
+++ b/src/main/java/net/sf/jmimemagic/Magic.java
@@ -28,7 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -43,6 +43,7 @@ import java.util.Iterator;
  */
 public class Magic
 {
+    private static String magicFile = "/magic.xml";
     private static Log log = LogFactory.getLog(Magic.class);
     private static boolean initialized = false;
     private static MagicParser magicParser = null;
@@ -51,7 +52,7 @@ public class Magic
     /**
      * constructor
      */
-    public Magic()
+    private Magic()
     {
         log.debug("instantiated");
     }
@@ -82,12 +83,36 @@ public class Magic
     public static synchronized void initialize()
         throws MagicParseException
     {
+        // get the magic file URL
+        URL magicURL = MagicParser.class.getResource(magicFile);
+
+        if (magicURL == null) {
+            log.error("initialize(): couldn't load '" + magicURL + "'");
+            throw new MagicParseException("couldn't load '" + magicURL + "'");
+        }
+        
+        initialize(magicURL);
+     }
+
+    public static synchronized void reset() {
+    	initialized = false;
+    	hintMap.clear();
+    }
+    
+   /**
+     * create a parser and initialize it with the provided match configuration XML
+     *
+     * @throws MagicParseException DOCUMENT ME!
+     */
+    public static synchronized void initialize(URL magicXmlUrl)
+        throws MagicParseException
+    {
         log.debug("initialize()");
 
         if (!initialized) {
             log.debug("initializing");
             magicParser = new MagicParser();
-            magicParser.initialize();
+            magicParser.initialize(magicXmlUrl);
 
             // build hint map
             Iterator i = magicParser.getMatchers().iterator();

--- a/src/main/java/net/sf/jmimemagic/MagicDtdResolver.java
+++ b/src/main/java/net/sf/jmimemagic/MagicDtdResolver.java
@@ -1,0 +1,32 @@
+package net.sf.jmimemagic;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public class MagicDtdResolver implements EntityResolver {
+	private static final String MAGIC_DTD_PUBLIC_ID = "-//jmimemagic//DTD magic config 1.0//EN";
+	
+	private InputStream dtdStream;
+	
+	public MagicDtdResolver() {
+		this(MagicDtdResolver.class.getResourceAsStream("/magic_1_0.dtd"));
+	}
+	
+	public MagicDtdResolver(InputStream dtdStream) {
+		super();
+		this.dtdStream = dtdStream;
+	}
+
+	@Override
+	public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+		if (MAGIC_DTD_PUBLIC_ID.equals(publicId)) {
+			return new InputSource(dtdStream);
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/net/sf/jmimemagic/MagicParser.java
+++ b/src/main/java/net/sf/jmimemagic/MagicParser.java
@@ -24,7 +24,6 @@ package net.sf.jmimemagic;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.ErrorHandler;
@@ -37,9 +36,9 @@ import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
 
 import java.io.ByteArrayOutputStream;
-
+import java.io.InputStream;
+import java.net.URL;
 import java.nio.ByteBuffer;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,7 +52,6 @@ import java.util.HashMap;
   */
 public class MagicParser extends DefaultHandler implements ContentHandler, ErrorHandler
 {
-    private static String magicFile = "/magic.xml";
     private static Log log = LogFactory.getLog(MagicParser.class);
 
     // Namespaces feature id (http://xml.org/sax/features/namespaces).
@@ -102,13 +100,13 @@ public class MagicParser extends DefaultHandler implements ContentHandler, Error
     {
         log.debug("instantiated");
     }
-
+    
     /**
-     * parse the xml file and create our MagicMatcher object list
+     * parse the provided xml and create our MagicMatcher object list
      *
      * @throws MagicParseException DOCUMENT ME!
      */
-    public synchronized void initialize()
+    public synchronized void initialize(URL magicXmlUrl)
         throws MagicParseException
     {
         boolean namespaces = DEFAULT_NAMESPACES;
@@ -166,17 +164,13 @@ public class MagicParser extends DefaultHandler implements ContentHandler, Error
             parser.setErrorHandler(this);
             parser.setContentHandler(this);
 
+            // set resolver for DTD
+            parser.setEntityResolver(new MagicDtdResolver());
+            
             // parse file
             try {
-                // get the magic file URL
-                String magicURL = MagicParser.class.getResource(magicFile).toString();
 
-                if (magicURL == null) {
-                    log.error("initialize(): couldn't load '" + magicURL + "'");
-                    throw new MagicParseException("couldn't load '" + magicURL + "'");
-                }
-
-                parser.parse(magicURL);
+                parser.parse(magicXmlUrl.toString());
             } catch (SAXParseException e) {
                 // ignore
             } catch (Exception e) {

--- a/src/main/resources/magic.xml
+++ b/src/main/resources/magic.xml
@@ -2882,13 +2882,7 @@
 	<mimetype>text/html</mimetype>
 	<extension>html</extension>
 	<description>HTML document text</description>
-	<test offset="0" type="string" comparator="=">&lt;!DOCTYPE HTML</test>
-</match>
-<match>
-	<mimetype>text/html</mimetype>
-	<extension>html</extension>
-	<description>HTML document text</description>
-	<test offset="0" type="string" comparator="=">&lt;!doctype html</test>
+	<test offset="0" type="regex" comparator="=">/^\s*&lt;!DOCTYPE HTML/i</test>
 </match>
 <match>
 	<mimetype>text/html</mimetype>

--- a/src/test/java/net/sf/jmimemagic/CustomXmlTest.java
+++ b/src/test/java/net/sf/jmimemagic/CustomXmlTest.java
@@ -1,0 +1,26 @@
+package net.sf.jmimemagic;
+
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+
+import junit.framework.*;
+
+public class CustomXmlTest extends TestCase {
+	
+	public void testHelloWorld() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		Magic.reset();
+		Magic.initialize(getClass().getResource("/config/custom_magic.xml"));
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/custom/hello.world")));
+		assertEquals("text/custom", match.getMimeType());
+	}
+
+	public void test() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		Magic.initialize(getClass().getResource("/config/custom_magic.xml"));
+		// disable
+		Magic.reset();
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/custom/hello.world")));
+		assertFalse("text/custom".equals(match.getMimeType()));
+	}
+
+}

--- a/src/test/java/net/sf/jmimemagic/HtmlDetectionTest.java
+++ b/src/test/java/net/sf/jmimemagic/HtmlDetectionTest.java
@@ -1,0 +1,52 @@
+package net.sf.jmimemagic;
+
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+
+import junit.framework.*;
+
+public class HtmlDetectionTest extends TestCase {
+	public void testDoctypeLower() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/doctype_lower.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+	public void testDoctypeMixed1() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/doctype_mixed1.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+	public void testDoctypeMixed2() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/doctype_mixed2.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+	public void testDoctypeUpper() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/doctype_upper.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+	public void testNoDoctypeLower() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/no_doctype_lower.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+	public void testNoDoctypeUpper() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/no_doctype_upper.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+
+	public void testNoHtmlLower() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/no_html_lower.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+
+	public void testNoHtmlUpper() throws MagicParseException, MagicMatchNotFoundException, MagicException, IOException {
+		MagicMatch match = Magic.getMagicMatch(IOUtils.toByteArray(getClass().getResourceAsStream("/html/no_html_upper.html")));
+		assertEquals("text/html", match.getMimeType());
+	}
+
+}

--- a/src/test/resources/config/custom_magic.xml
+++ b/src/test/resources/config/custom_magic.xml
@@ -1,0 +1,3555 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE magic PUBLIC "-//jmimemagic//DTD magic config 1.0//EN" "magic_1_0.dtd">
+<magic>
+<info>
+<version>custom</version>
+<author>abaudet</author>
+<description>magic file</description>
+</info>
+<match-list>
+<match>
+	<mimetype>text/custom</mimetype>
+	<extension></extension>
+	<description>Hello World</description>
+	<test type="string" offset="0" length="" bitmask="" comparator="=">Hello world</test>
+</match>
+
+
+
+<match>
+	<mimetype>audio/mp3</mimetype>
+	<extension></extension>
+	<description>MP3</description>
+	<test type="beshort" offset="0" length="" bitmask="0xfffe" comparator="=">0xfffa</test>
+	<match-list>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 32 kBits</description>
+		<property name="bitrate" value="32"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x10</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 40 kBits</description>
+		<property name="bitrate" value="40"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x20</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 48 kBits</description>
+		<property name="bitrate" value="48"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x30</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 56 kBits</description>
+		<property name="bitrate" value="56"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x40</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 64 kBits</description>
+		<property name="bitrate" value="64"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x50</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 80 kBits</description>
+		<property name="bitrate" value="80"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x60</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 96 kBits</description>
+		<property name="bitrate" value="96"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x70</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 112 kBits</description>
+		<property name="bitrate" value="112"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x80</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 128 kBits</description>
+		<property name="bitrate" value="128"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0x90</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 160 kBits</description>
+		<property name="bitrate" value="160"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0xA0</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 192 kBits</description>
+		<property name="bitrate" value="192"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0xB0</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 224 kBits</description>
+		<property name="bitrate" value="224"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0xC0</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 256 kBits</description>
+		<property name="bitrate" value="256"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0xD0</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 320 kBits</description>
+		<property name="bitrate" value="320"/>
+		<test type="byte" offset="2" length="" bitmask="0xf0" comparator="=">0xE0</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 44.1 kHz</description>
+		<property name="samplingrate" value="44.1"/>
+		<test type="byte" offset="2" length="" bitmask="0x0C" comparator="=">0x00</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 48 kHz</description>
+		<property name="samplingrate" value="48"/>
+		<test type="byte" offset="2" length="" bitmask="0x0C" comparator="=">0x04</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, 32 kHz</description>
+		<property name="samplingrate" value="32"/>
+		<test type="byte" offset="2" length="" bitmask="0x0C" comparator="=">0x08</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, Stereo</description>
+		<property name="channels" value="stereo"/>
+		<test type="byte" offset="3" length="" bitmask="0xC0" comparator="=">0x00</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, JStereo</description>
+		<property name="channels" value="jstereo"/>
+		<test type="byte" offset="3" length="" bitmask="0xC0" comparator="=">0x40</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, Dual-Ch</description>
+		<property name="channels" value="dual"/>
+		<test type="byte" offset="3" length="" bitmask="0xC0" comparator="=">0x80</test>
+	</match>
+	<match>
+		<mimetype></mimetype>
+		<extension></extension>
+		<description>b, Mono</description>
+		<property name="channels" value="mono"/>
+		<test type="byte" offset="3" length="" bitmask="0xC0" comparator="=">0xC0</test>
+	</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>image/gif</mimetype>
+	<extension></extension>
+	<description>GIF image data</description>
+	<test type="string" offset="0" length="" bitmask="" comparator="=">GIF8</test>
+	<match-list>
+	<match>
+		<mimetype>b, version 8%s,</mimetype>
+		<extension></extension>
+		<description>b, version 8%s,</description>
+		<test type="string" offset="4" length="" bitmask="" comparator="=">7a</test>
+	</match>
+	<match>
+		<mimetype>b, version 8%s,</mimetype>
+		<extension></extension>
+		<description>b, version 8%s,</description>
+		<test type="string" offset="4" length="" bitmask="" comparator="=">9a</test>
+	</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>video/mpeg</mimetype>
+	<extension>mpg</extension>
+	<description>MPEG video stream data</description>
+	<test offset="0" type="belong" comparator="=">0x1b3</test>
+</match>
+<match>
+	<mimetype>video/mpeg</mimetype>
+	<extension>mpg</extension>
+	<description>MPEG system stream data</description>
+	<test offset="0" type="belong" comparator="=">0x1ba</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>MP</description>
+	<test offset="0" type="beshort" comparator="&amp;">0xfff0</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>\b</description>
+			<test offset="1" type="byte" comparator="=">0x8</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>\b3</description>
+					<test offset="1" type="byte" comparator="&amp;">0x2</test>
+					<match-list>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 32 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x10</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 40 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x20</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 48 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x30</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 56 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x40</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 64 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x50</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 80 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x60</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 96 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x70</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>112 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x80</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>128 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x90</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>160 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xa0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>192 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xb0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>224 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xc0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>256 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xd0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>320 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xe0</test>
+						</match>
+					</match-list>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>\b2</description>
+					<test offset="1" type="byte" comparator="&amp;">0x4</test>
+					<match-list>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 32 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x10</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 48 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x20</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 56 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x30</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 64 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x40</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 80 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x50</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description> 96 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x60</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>112 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x70</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>128 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x80</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>160 kBits</description>
+							<test offset="2" type="byte" comparator="=">0x90</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>192 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xa0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>224 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xb0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>256 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xc0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>320 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xd0</test>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>384 kBits</description>
+							<test offset="2" type="byte" comparator="=">0xe0</test>
+						</match>
+					</match-list>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>44.1 kHz</description>
+					<test offset="2" type="byte" comparator="=">0x0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>48 kHz</description>
+					<test offset="2" type="byte" comparator="=">0x4</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>32 kHz</description>
+					<test offset="2" type="byte" comparator="=">0x8</test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>\b</description>
+			<test offset="1" type="byte" comparator="=">0x0</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>\b3</description>
+					<test offset="1" type="byte" comparator="&amp;">0x2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>\b2</description>
+					<test offset="1" type="byte" comparator="&amp;">0x4</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>  8 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x10</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 16 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x20</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 24 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x30</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 32 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x40</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 40 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x50</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 48 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x60</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 56 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x70</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 64 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x80</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 80 kBits</description>
+					<test offset="2" type="byte" comparator="=">0x90</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description> 96 kBits</description>
+					<test offset="2" type="byte" comparator="=">0xa0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>112 kBits</description>
+					<test offset="2" type="byte" comparator="=">0xb0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>128 kBits</description>
+					<test offset="2" type="byte" comparator="=">0xc0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>144 kBits</description>
+					<test offset="2" type="byte" comparator="=">0xd0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>160 kBits</description>
+					<test offset="2" type="byte" comparator="=">0xe0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>22.05 kHz</description>
+					<test offset="2" type="byte" comparator="=">0x0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>24 kHz</description>
+					<test offset="2" type="byte" comparator="=">0x4</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>16 kHz</description>
+					<test offset="2" type="byte" comparator="=">0x8</test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Stereo</description>
+			<test offset="3" type="byte" comparator="=">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>JStereo</description>
+			<test offset="3" type="byte" comparator="=">0x40</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Dual-Ch</description>
+			<test offset="3" type="byte" comparator="=">0x80</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Mono</description>
+			<test offset="3" type="byte" comparator="=">0xc0</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>FLI file</description>
+	<test offset="4" type="leshort" comparator="=">0xaf11</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>- %d frames,</description>
+			<test offset="6" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>width=%d pixels,</description>
+			<test offset="8" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>height=%d pixels,</description>
+			<test offset="10" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>depth=%d,</description>
+			<test offset="12" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>ticks/frame=%d</description>
+			<test offset="16" type="leshort" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>FLC file</description>
+	<test offset="4" type="leshort" comparator="=">0xaf12</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>- %d frames</description>
+			<test offset="6" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>width=%d pixels,</description>
+			<test offset="8" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>height=%d pixels,</description>
+			<test offset="10" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>depth=%d,</description>
+			<test offset="12" type="leshort" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>ticks/frame=%d</description>
+			<test offset="16" type="leshort" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Silicon Graphics movie file</description>
+	<test offset="0" type="string" comparator="=">MOVI</test>
+</match>
+<match>
+	<mimetype>video/quicktime</mimetype>
+	<extension>mov</extension>
+	<description>Apple QuickTime movie file (moov)</description>
+	<test offset="4" type="string" comparator="=">moov</test>
+</match>
+<match>
+	<mimetype>video/quicktime</mimetype>
+	<extension>mov</extension>
+	<description>Apple QuickTime movie file (mdat)</description>
+	<test offset="4" type="string" comparator="=">mdat</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Applixware</description>
+	<test offset="0" type="string" comparator="=">*BEGIN</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Words Document</description>
+			<test offset="7" type="string" comparator="=">WORDS</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Graphic</description>
+			<test offset="7" type="string" comparator="=">GRAPHICS</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Bitmap</description>
+			<test offset="7" type="string" comparator="=">RASTER</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Spreadsheet</description>
+			<test offset="7" type="string" comparator="=">SPREADSHEETS</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Macro</description>
+			<test offset="7" type="string" comparator="=">MACRO</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Builder Object</description>
+			<test offset="7" type="string" comparator="=">BUILDER</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/x-tar</mimetype>
+	<extension>tar</extension>
+	<description>POSIX tar archive</description>
+	<test offset="257" type="string" comparator="=">ustar </test>
+</match>
+<match>
+	<mimetype>application/x-tar</mimetype>
+	<extension>tar</extension>
+	<description>tar archive</description>
+	<test offset="257" type="string" comparator="=">ustar  \000GNU</test>
+</match>
+<match>
+  <mimetype>application/vnd.openxmlformats-officedocument.wordprocessingml.document</mimetype>
+  <extension>docx</extension>
+  <description>Microsoft Office Open XML Document</description>
+  <test offset="0" type="string" comparator="=">PK\003\004</test>
+</match>
+<match>
+  <mimetype>application/vnd.openxmlformats-officedocument.wordprocessingml.document</mimetype>
+  <extension>docm</extension>
+  <description>Microsoft Office Open XML Document</description>
+  <test offset="0" type="string" comparator="=">PK\003\004</test>
+</match>
+<match>
+  <mimetype>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</mimetype>
+  <extension>xlsx</extension>
+  <description>Microsoft Office Open XML Workbook</description>
+  <test offset="0" type="string" comparator="=">PK\003\004</test>
+</match>
+<match>
+  <mimetype>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</mimetype>
+  <extension>xlsm</extension>
+  <description>Microsoft Office Open XML Workbook</description>
+  <test offset="0" type="string" comparator="=">PK\003\004</test>
+</match>
+<match>
+  <mimetype>application/vnd.openxmlformats-officedocument.presentationml.presentation</mimetype>
+  <extension>pptx</extension>
+  <description>Microsoft Office Open XML Workbook</description>
+  <test offset="0" type="string" comparator="=">PK\003\004</test>
+</match>
+<match>
+  <mimetype>application/vnd.openxmlformats-officedocument.presentationml.presentation</mimetype>
+  <extension>pptm</extension>
+  <description>Microsoft Office Open XML Workbook</description>
+  <test offset="0" type="string" comparator="=">PK\003\004</test>
+</match>
+<match>
+	<mimetype>application/zip</mimetype>
+	<extension>zip</extension>
+	<description>Zip archive data</description>
+	<test offset="0" type="string" comparator="=">PK\003\004</test>
+	<match-list>
+		<match>
+			<mimetype>application/zip</mimetype>
+			<extension>zip</extension>
+			<description>at least v0.9 to extract</description>
+			<test offset="4" type="byte" comparator="=">0x9</test>
+		</match>
+		<match>
+			<mimetype>application/zip</mimetype>
+			<extension>zip</extension>
+			<description>at least v1.0 to extract</description>
+			<test offset="4" type="byte" comparator="=">0xa</test>
+		</match>
+		<match>
+			<mimetype>application/zip</mimetype>
+			<extension>zip</extension>
+			<description>at least v1.1 to extract</description>
+			<test offset="4" type="byte" comparator="=">0xb</test>
+		</match>
+		<match>
+			<mimetype>application/zip</mimetype>
+			<extension>zip</extension>
+			<description>at least v2.0 to extract</description>
+			<test offset="4" type="byte" comparator="=">0x14</test>
+		</match>
+    </match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Standard MIDI data</description>
+	<test offset="0" type="string" comparator="=">MThd</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(format %d)</description>
+			<test offset="9" type="byte" comparator="&gt;">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>using %d tracks</description>
+			<test offset="11" type="byte" comparator="&gt;">0x1</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Creative Music (CMF) data</description>
+	<test offset="0" type="string" comparator="=">CTMF</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>SoundBlaster instrument data</description>
+	<test offset="0" type="string" comparator="=">SBI</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Creative Labs voice data</description>
+	<test offset="0" type="string" comparator="=">Creative Voice File</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description></description>
+			<test offset="19" type="byte" comparator="=">0x1a</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>- version %d</description>
+			<test offset="23" type="byte" comparator="&gt;">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>\b.%d</description>
+			<test offset="22" type="byte" comparator="&gt;">0x0</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Extended MOD sound data,</description>
+	<test offset="0" type="string" comparator="=">EMOD</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>version %d</description>
+			<test offset="4" type="byte" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>\b.%d,</description>
+			<test offset="4" type="byte" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%d instruments</description>
+			<test offset="45" type="byte" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(module)</description>
+			<test offset="83" type="byte" comparator="=">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(song)</description>
+			<test offset="83" type="byte" comparator="=">0x1</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>realaudio sound file</description>
+	<test offset="0" type="belong" comparator="=">0x2e7261fd</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>file        </description>
+	<test offset="0" type="string" comparator="=">.RMF\000\000\000realmedia</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>data</description>
+	<test offset="0" type="string" comparator="=">\037\235compress'd</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>block compressed</description>
+			<test offset="2" type="byte" comparator="&gt;">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%d bits</description>
+			<test offset="2" type="byte" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/x-gzip</mimetype>
+	<extension>gz</extension>
+	<description>gzip compressed data</description>
+	<test offset="0" type="string" comparator="=">\037\213</test>
+	<match-list>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>reserved method,</description>
+			<test offset="2" type="byte" comparator="&lt;">0x8</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>deflated,</description>
+			<test offset="2" type="byte" comparator="=">0x8</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>ASCII,</description>
+			<test offset="3" type="byte" comparator="&amp;">0x1</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>continuation,</description>
+			<test offset="3" type="byte" comparator="&amp;">0x2</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>extra field,</description>
+			<test offset="3" type="byte" comparator="&amp;">0x4</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>original filename,</description>
+			<test offset="3" type="byte" comparator="&amp;">0x8</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>comment,</description>
+			<test offset="3" type="byte" comparator="&amp;">0x10</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>encrypted,</description>
+			<test offset="3" type="byte" comparator="&amp;">0x20</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>last modified: %s,</description>
+			<test offset="4" type="ledate" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>max compression,</description>
+			<test offset="8" type="byte" comparator="=">0x2</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>max speed,</description>
+			<test offset="8" type="byte" comparator="=">0x4</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: MS-DOS</description>
+			<test offset="9" type="byte" comparator="=">0x0</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: Amiga</description>
+			<test offset="9" type="byte" comparator="=">0x1</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: VMS</description>
+			<test offset="9" type="byte" comparator="=">0x2</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: Unix</description>
+			<test offset="9" type="byte" comparator="=">0x3</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: Atari</description>
+			<test offset="9" type="byte" comparator="=">0x5</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: OS/2</description>
+			<test offset="9" type="byte" comparator="=">0x6</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: MacOS</description>
+			<test offset="9" type="byte" comparator="=">0x7</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: Tops/20</description>
+			<test offset="9" type="byte" comparator="=">0xa</test>
+		</match>
+		<match>
+			<mimetype>application/x-gzip</mimetype>
+			<extension>gz</extension>
+			<description>os: Win/32</description>
+			<test offset="9" type="byte" comparator="=">0xb</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/x-bzip2</mimetype>
+	<extension>bz2</extension>
+	<description>bzip2 compressed data</description>
+	<test offset="0" type="string" comparator="=">BZh</test>
+	<match-list>
+		<match>
+			<mimetype>application/x-bzip2</mimetype>
+			<extension>bz2</extension>
+			<description>block size = %c00k</description>
+			<test offset="3" type="byte" comparator="&gt;">0x2f</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/x-shockwave-flash</mimetype>
+	<extension>swf</extension>
+	<description>Macromedia Flash data,</description>
+	<test offset="0" type="string" comparator="=">FWS</test>
+	<match-list>
+		<match>
+			<mimetype>application/x-shockwave-flash</mimetype>
+			<extension>swf</extension>
+			<description>version %d</description>
+			<test offset="3" type="byte" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PostScript Type 1 font text</description>
+	<test offset="0" type="string" comparator="=">%!PS-AdobeFont-1.</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(%s)</description>
+			<test offset="20" type="string" comparator="&gt;">\000</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PostScript Type 1 font program data</description>
+	<test offset="6" type="string" comparator="=">%!PS-AdobeFont-1.0</test>
+</match>
+<match>
+	<mimetype>application/postscript</mimetype>
+	<extension>ps</extension>
+	<description>PostScript Level 2 program data</description>
+	<test offset="0" type="string" comparator="=">%!PS-Adobe-2.0</test>
+</match>
+<match>
+	<mimetype>application/vnd.framemaker</mimetype>
+	<extension>???</extension>
+	<description>FrameMaker document</description>
+	<test offset="0" type="string" comparator="=">&lt;MakerFile</test>
+	<match-list>
+		<match>
+			<mimetype>application/vnd.framemaker</mimetype>
+			<extension>???</extension>
+			<description>(5.5</description>
+			<test offset="11" type="string" comparator="=">5.5</test>
+		</match>
+		<match>
+			<mimetype>application/vnd.framemaker</mimetype>
+			<extension>???</extension>
+			<description>(5.0</description>
+			<test offset="11" type="string" comparator="=">5.0</test>
+		</match>
+		<match>
+			<mimetype>application/vnd.framemaker</mimetype>
+			<extension>???</extension>
+			<description>(4.0</description>
+			<test offset="11" type="string" comparator="=">4.0</test>
+		</match>
+		<match>
+			<mimetype>application/vnd.framemaker</mimetype>
+			<extension>???</extension>
+			<description>(3.0</description>
+			<test offset="11" type="string" comparator="=">3.0</test>
+		</match>
+		<match>
+			<mimetype>application/vnd.framemaker</mimetype>
+			<extension>???</extension>
+			<description>(2.0</description>
+			<test offset="11" type="string" comparator="=">2.0</test>
+		</match>
+		<match>
+			<mimetype>application/vnd.framemaker</mimetype>
+			<extension>???</extension>
+			<description>(1.0</description>
+			<test offset="11" type="string" comparator="=">1.0</test>
+		</match>
+		<match>
+			<mimetype>application/vnd.framemaker</mimetype>
+			<extension>???</extension>
+			<description>%c)</description>
+			<test offset="14" type="byte" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>FrameMaker MIF (ASCII) file</description>
+	<test offset="0" type="string" comparator="=">&lt;MIFFile</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(4.0)</description>
+			<test offset="9" type="string" comparator="=">4.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(3.0)</description>
+			<test offset="9" type="string" comparator="=">3.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(2.0)</description>
+			<test offset="9" type="string" comparator="=">2.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(1.x)</description>
+			<test offset="9" type="string" comparator="=">1.0</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>FrameMaker Dictionary text</description>
+	<test offset="0" type="string" comparator="=">&lt;MakerDictionary</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(3.0)</description>
+			<test offset="17" type="string" comparator="=">3.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(2.0)</description>
+			<test offset="17" type="string" comparator="=">2.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(1.x)</description>
+			<test offset="17" type="string" comparator="=">1.0</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>FrameMaker Font file</description>
+	<test offset="0" type="string" comparator="=">&lt;MakerScreenFont</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(%s)</description>
+			<test offset="17" type="string" comparator="=">1.01</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>FrameMaker MML file</description>
+	<test offset="0" type="string" comparator="=">&lt;MML</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>FrameMaker Book file</description>
+	<test offset="0" type="string" comparator="=">&lt;BookFile</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(3.0</description>
+			<test offset="10" type="string" comparator="=">3.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(2.0</description>
+			<test offset="10" type="string" comparator="=">2.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>(1.0</description>
+			<test offset="10" type="string" comparator="=">1.0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%c)</description>
+			<test offset="13" type="byte" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Intermediate Print File	FrameMaker IPL file</description>
+	<test offset="0" type="string" comparator="=">&lt;Maker</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>GIMP gradient data</description>
+	<test offset="0" type="string" comparator="=">GIMP Gradient</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>GIMP XCF image data,</description>
+	<test offset="0" type="string" comparator="=">gimp xcf file</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%ld x</description>
+			<test offset="14" type="belong" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%ld,</description>
+			<test offset="18" type="belong" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>RGB Color</description>
+			<test offset="22" type="belong" comparator="=">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Greyscale</description>
+			<test offset="22" type="belong" comparator="=">0x1</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Indexed Color</description>
+			<test offset="22" type="belong" comparator="=">0x2</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>GIMP pattern data,</description>
+	<test offset="20" type="string" comparator="=">GPAT</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%s</description>
+			<test offset="24" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>GIMP brush data</description>
+	<test offset="20" type="string" comparator="=">GIMP</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PBM image text</description>
+	<test offset="0" type="string" comparator="=">P1</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PGM image text</description>
+	<test offset="0" type="string" comparator="=">P2</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PPM image text</description>
+	<test offset="0" type="string" comparator="=">P3</test>
+</match>
+<match>
+	<mimetype>image/x-portable-bitmap</mimetype>
+	<extension>pbm</extension>
+	<description>PBM "rawbits" image data</description>
+	<test offset="0" type="string" comparator="=">P4</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PGM "rawbits" image data</description>
+	<test offset="0" type="string" comparator="=">P5</test>
+</match>
+<match>
+	<mimetype>image/x-portable-graymap</mimetype>
+	<extension>???</extension>
+	<description>PPM "rawbits" image data</description>
+	<test offset="0" type="string" comparator="=">P6</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>NIFF image data</description>
+	<test offset="0" type="string" comparator="=">IIN1</test>
+</match>
+<match>
+    <mimetype>image/tiff</mimetype>
+	<extension>tif</extension>
+	<description>TIFF image data, big-endian</description>
+	<test offset="0" type="string" comparator="=">MM\000\052</test>
+</match>
+<match>
+    <mimetype>image/tiff</mimetype>
+    <extension>tif</extension>
+	<description>TIFF image data, little-endian</description>
+	<test offset="0" type="string" comparator="=">II\052\000</test>
+</match>
+<match>
+    <mimetype>image/tiff</mimetype>
+	<extension>tiff</extension>
+	<description>TIFF image data, big-endian</description>
+	<test offset="0" type="string" comparator="=">MM\000\052</test>
+</match>
+<match>
+    <mimetype>image/tiff</mimetype>
+    <extension>tiff</extension>
+	<description>TIFF image data, little-endian</description>
+	<test offset="0" type="string" comparator="=">II\052\000</test>
+</match>
+<match>
+	<mimetype>image/png</mimetype>
+	<extension>png</extension>
+	<description>PNG image data,</description>
+	<test offset="0" type="string" comparator="=">\211NG</test>
+	<match-list>
+		<match>
+			<mimetype>image/png</mimetype>
+			<extension>png</extension>
+			<description>CORRUPTED,</description>
+			<test offset="4" type="belong" comparator="=">0xd0a1a0a</test>
+		</match>
+		<match>
+			<mimetype>image/png</mimetype>
+			<extension>png</extension>
+			<description></description>
+			<test offset="4" type="belong" comparator="=">0xd0a1a0a</test>
+			<match-list>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>%ld x</description>
+					<test offset="16" type="belong" comparator="="></test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>%ld,</description>
+					<test offset="20" type="belong" comparator="="></test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>%d-bit</description>
+					<test offset="24" type="byte" comparator="="></test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>grayscale,</description>
+					<test offset="25" type="byte" comparator="=">0x0</test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>\b/color RGB,</description>
+					<test offset="25" type="byte" comparator="=">0x2</test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>colormap,</description>
+					<test offset="25" type="byte" comparator="=">0x3</test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>gray+alpha,</description>
+					<test offset="25" type="byte" comparator="=">0x4</test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>\b/color RGBA,</description>
+					<test offset="25" type="byte" comparator="=">0x6</test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>non-interlaced</description>
+					<test offset="28" type="byte" comparator="=">0x0</test>
+				</match>
+				<match>
+					<mimetype>image/png</mimetype>
+					<extension>png</extension>
+					<description>interlaced</description>
+					<test offset="28" type="byte" comparator="=">0x1</test>
+				</match>
+			</match-list>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>image/png</mimetype>
+	<extension>png</extension>
+	<description>PNG image data, CORRUPTED</description>
+	<test offset="1" type="string" comparator="=">PNG</test>
+</match>
+<match>
+	<mimetype>image/gif</mimetype>
+	<extension>gif</extension>
+	<description>GIF image data</description>
+	<test offset="0" type="string" comparator="=">GIF8</test>
+	<match-list>
+		<match>
+			<mimetype>image/gif</mimetype>
+			<extension>gif</extension>
+			<description>version 8%s,</description>
+			<test offset="4" type="string" comparator="=">7a</test>
+		</match>
+		<match>
+			<mimetype>image/gif</mimetype>
+			<extension>gif</extension>
+			<description>version 8%s,</description>
+			<test offset="4" type="string" comparator="=">9a</test>
+		</match>
+		<match>
+			<mimetype>image/gif</mimetype>
+			<extension>gif</extension>
+			<description>%hd x</description>
+			<test offset="6" type="leshort" comparator="&gt;">0x0</test>
+		</match>
+		<match>
+			<mimetype>image/gif</mimetype>
+			<extension>gif</extension>
+			<description>%hd,</description>
+			<test offset="8" type="leshort" comparator="&gt;">0x0</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>window manager raster image data</description>
+	<test offset="0" type="string" comparator="=">\361\000@\273CMU</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%d x</description>
+			<test offset="4" type="lelong" comparator="&gt;">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%d,</description>
+			<test offset="8" type="lelong" comparator="&gt;">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%d-bit</description>
+			<test offset="12" type="lelong" comparator="&gt;">0x0</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/x-miff</mimetype>
+	<extension>miff</extension>
+	<description>MIFF image data</description>
+	<test offset="0" type="string" comparator="=">id=ImageMagick</test>
+</match>
+<match>
+	<mimetype>image/g3fax</mimetype>
+	<extension>fax</extension>
+	<description>group 3 fax data</description>
+	<test offset="1" type="string" comparator="=">PC Research, Inc</test>
+	<match-list>
+		<match>
+			<mimetype>image/g3fax</mimetype>
+			<extension>fax</extension>
+			<description>normal resolution (204x98 DPI)</description>
+			<test offset="29" type="byte" comparator="=">0x0</test>
+		</match>
+		<match>
+			<mimetype>image/g3fax</mimetype>
+			<extension>fax</extension>
+			<description>fine resolution (204x196 DPI)</description>
+			<test offset="29" type="byte" comparator="=">0x1</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>image/jpeg</mimetype>
+	<extension>jpg</extension>
+	<description>JPEG image data</description>
+	<test offset="0" type="beshort" comparator="=">0xffd8</test>
+	<match-list>
+		<match>
+			<mimetype>image/jpeg</mimetype>
+			<extension>jpg</extension>
+			<description>JFIF standard</description>
+			<test offset="6" type="string" comparator="=">JFIF</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>image/jpeg</mimetype>
+	<extension>jpg</extension>
+	<description>JPEG image data, HSI proprietary</description>
+	<test offset="0" type="string" comparator="=">hsi1</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PC icon data</description>
+	<test offset="0" type="string" comparator="=">IC</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PC pointer image data</description>
+	<test offset="0" type="string" comparator="=">PI</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PC color icon data</description>
+	<test offset="0" type="string" comparator="=">CI</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PC color pointer image data</description>
+	<test offset="0" type="string" comparator="=">CP</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>X pixmap image text</description>
+	<test offset="0" type="string" comparator="=">/* XPM */</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>iff image data</description>
+	<test offset="0" type="string" comparator="=">Imagefile version-</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%s</description>
+			<test offset="10" type="string" comparator="&gt;">\000</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Kodak Photo CD image pack file</description>
+	<test offset="2048" type="string" comparator="=">PCD_IPI</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Kodak Photo CD overview pack file</description>
+	<test offset="0" type="string" comparator="=">PCD_OPA</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>%s</description>
+	<test offset="1536" type="string" comparator="=">Visio (TM) Drawing</test>
+</match>
+<match>
+	<mimetype>application/java</mimetype>
+	<extension>class</extension>
+	<description>Compiled Java Class Data</description>
+	<test offset="0" type="belong" comparator="=">0xcafebabe</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Java Class Version 1.2</description>
+			<test offset="4" type="belong" comparator="=">0x0000002e</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Java Class Version 1.3</description>
+			<test offset="4" type="belong" comparator="=">0x0000002f</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Java Class Version 1.4</description>
+			<test offset="4" type="belong" comparator="=">0x00000030</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Java Class Version 1.5</description>
+			<test offset="4" type="belong" comparator="=">0x00000031</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Java serialization data</description>
+	<test offset="0" type="beshort" comparator="=">0xaced</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>version %d</description>
+			<test offset="2" type="beshort" comparator="&gt;">0x4</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/mac-binhex40</mimetype>
+	<extension>???</extension>
+	<description>BinHex binary text</description>
+	<test offset="11" type="string" comparator="=">must be converted with BinHex</test>
+	<match-list>
+		<match>
+			<mimetype>application/mac-binhex40</mimetype>
+			<extension>???</extension>
+			<description>version %.3s</description>
+			<test offset="41" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>StuffIt Archive (data)</description>
+	<test offset="0" type="string" comparator="=">SIT!</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>StuffIt Archive (rsrc + data)</description>
+	<test offset="65" type="string" comparator="=">SIT!</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>StuffIt Deluxe (data)</description>
+	<test offset="0" type="string" comparator="=">SITD</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>StuffIt Deluxe (rsrc + data)</description>
+	<test offset="65" type="string" comparator="=">SITD</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>StuffIt Deluxe Segment (data)</description>
+	<test offset="0" type="string" comparator="=">Seg</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>StuffIt Deluxe Segment (rsrc + data)</description>
+	<test offset="65" type="string" comparator="=">Seg</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/pdf</mimetype>
+	<extension>pdf</extension>
+	<description>Macintosh PDF File (data)</description>
+	<test offset="0" type="string" comparator="=">PDF</test>
+	<match-list>
+		<match>
+			<mimetype>application/pdf</mimetype>
+			<extension>pdf</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>application/pdf</mimetype>
+	<extension>pdf</extension>
+	<description>Macintosh PDF File(rsrc + data)</description>
+	<test offset="65" type="string" comparator="=">PDF</test>
+	<match-list>
+		<match>
+			<mimetype>application/pdf</mimetype>
+			<extension>pdf</extension>
+			<description>: %s</description>
+			<test offset="2" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>MIME entity text</description>
+	<test offset="0" type="string" comparator="=">MIME-Version:</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description></description>
+	<test offset="0" type="string" comparator="=">Content-Type:</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%s</description>
+			<test offset="14" type="string" comparator="&gt;">\000</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description></description>
+	<test offset="0" type="string" comparator="=">Content-Type</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%s</description>
+			<test offset="13" type="string" comparator="&gt;">\000</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>MS-DOS batch file text</description>
+	<test offset="0" type="string" comparator="=">@echo off</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Windows PE</description>
+	<test offset="128" type="string" comparator="=">PE\000\000MS</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>32-bit</description>
+			<test offset="150" type="leshort" comparator="&gt;">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>unknown processor</description>
+			<test offset="132" type="leshort" comparator="=">0x0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Intel 80386</description>
+			<test offset="132" type="leshort" comparator="=">0x14c</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>MIPS R4000</description>
+			<test offset="132" type="leshort" comparator="=">0x166</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Alpha</description>
+			<test offset="132" type="leshort" comparator="=">0x184</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Motorola 68000</description>
+			<test offset="132" type="leshort" comparator="=">0x268</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PowerPC</description>
+			<test offset="132" type="leshort" comparator="=">0x1f0</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PA-RISC</description>
+			<test offset="132" type="leshort" comparator="=">0x290</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description></description>
+			<test offset="148" type="leshort" comparator="&gt;">0x1b</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>unknown subsystem</description>
+					<test offset="220" type="leshort" comparator="=">0x0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>native</description>
+					<test offset="220" type="leshort" comparator="=">0x1</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>GUI</description>
+					<test offset="220" type="leshort" comparator="=">0x2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>console</description>
+					<test offset="220" type="leshort" comparator="=">0x3</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>POSIX</description>
+					<test offset="220" type="leshort" comparator="=">0x7</test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>executable</description>
+			<test offset="150" type="leshort" comparator="=">0x0</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>not relocatable</description>
+					<test offset="150" type="leshort" comparator="&gt;">0x0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>system file</description>
+					<test offset="150" type="leshort" comparator="&gt;">0x0</test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>DLL</description>
+			<test offset="150" type="leshort" comparator="&gt;">0x0</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>not relocatable</description>
+					<test offset="150" type="leshort" comparator="&gt;">0x0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>system file</description>
+					<test offset="150" type="leshort" comparator="&gt;">0x0</test>
+				</match>
+			</match-list>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>MS Windows COFF Intel 80386 object file</description>
+	<test offset="0" type="leshort" comparator="=">0x14c</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>MS-DOS executable (EXE)</description>
+	<test offset="0" type="string" comparator="=">MZ</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>OS/2 or MS Windows</description>
+			<test offset="24" type="string" comparator="=">@</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%s</description>
+					<test offset="231" type="string" comparator="=">LH/2 Self-Extract</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%s</description>
+					<test offset="233" type="string" comparator="=">PKSFX2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%s</description>
+					<test offset="122" type="string" comparator="=">Windows self-extracting ZIP</test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>ARJ SFX</description>
+			<test offset="28" type="string" comparator="=">RJSX\377\377b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>diet compressed</description>
+			<test offset="28" type="string" comparator="=">diet\371\234b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PKSFX</description>
+			<test offset="30" type="string" comparator="=">Copyright 1989-1990 PKWARE Inc.</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%.6s compressed</description>
+			<test offset="30" type="string" comparator="=">PKLITE Copr.</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%.15s</description>
+			<test offset="36" type="string" comparator="=">LHa's SFX</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>%.15s</description>
+			<test offset="36" type="string" comparator="=">LHA's SFX</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>LHa SFX archive v2.13S</description>
+			<test offset="1638" type="string" comparator="=">-lh5-</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>RAR self-extracting archive</description>
+			<test offset="7195" type="string" comparator="=">Rar!</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PKZIP SFX archive v1.1</description>
+			<test offset="11696" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PKZIP SFX archive v1.93a</description>
+			<test offset="13297" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PKZIP2 SFX archive v1.09</description>
+			<test offset="15588" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PKZIP SFX archive v2.04g</description>
+			<test offset="15770" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PKZIP2 SFX archive v1.02</description>
+			<test offset="28374" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Info-ZIP SFX archive v5.12</description>
+			<test offset="25115" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Info-ZIP SFX archive v5.12 w/decryption</description>
+			<test offset="26331" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Info-ZIP SFX archive v5.12</description>
+			<test offset="47031" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Info-ZIP SFX archive v5.12 w/decryption</description>
+			<test offset="49845" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Info-ZIP NT SFX archive v5.12 w/decryption</description>
+			<test offset="69120" type="string" comparator="=">PK\003\004b,</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>CODEC archive v3.21</description>
+			<test offset="49801" type="string" comparator="=">y\377\200\377v\377b,</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>1 file</description>
+					<test offset="49824" type="leshort" comparator="=">0x1</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%u files</description>
+					<test offset="49824" type="leshort" comparator="&gt;">0x1</test>
+				</match>
+			</match-list>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>MS-DOS executable (built-in)</description>
+	<test offset="0" type="string" comparator="=">LZ</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Windows NT Registry file</description>
+	<test offset="0" type="string" comparator="=">regf</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>%s</description>
+	<test offset="2080" type="string" comparator="=">Microsoft Word 6.0 Document</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>Spanish Microsoft Word 6 document data</description>
+	<test offset="2080" type="string" comparator="=">Documento Microsoft Word 6</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>Microsoft Word document data</description>
+	<test offset="2112" type="string" comparator="=">MSWordDoc</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>Microsoft Word Document</description>
+	<test offset="0" type="belong" comparator="=">0x31be0000</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>Microsoft Word 6.0 Document</description>
+	<test offset="0" type="string" comparator="=">PO^Q`</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>Microsoft Office Document</description>
+	<test offset="0" type="string" comparator="=">\376\067\000\043</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>Microsoft Office Document</description>
+	<test offset="0" type="string" comparator="=">\320\317\021\340\241\261</test>
+</match>
+<match>
+	<mimetype>application/msword</mimetype>
+	<extension>doc</extension>
+	<description>Microsoft Office Document</description>
+	<test offset="0" type="string" comparator="=">\333\245-\000\000\000</test>
+</match>
+<match>
+	<mimetype>application/msexcel</mimetype>
+	<extension>???</extension>
+	<description>%s</description>
+	<test offset="2080" type="string" comparator="=">Microsoft Excel 5.0 Worksheet</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Microsoft Excel 5.0 Worksheet</description>
+	<test offset="2114" type="string" comparator="=">Biff5</test>
+</match>
+<match>
+	<mimetype>text/xml</mimetype>
+	<extension>???</extension>
+	<description>XML 1.0 Document</description>
+	<test offset="0" type="string" comparator="=">&lt;?xml version="1.0"?&gt;</test>
+	<match-list>
+		<match>
+			<mimetype>application/msexcel</mimetype>
+			<extension>???</extension>
+			<description>Microsoft Excel Spreadsheet</description>
+			<test offset="23" type="string" comparator="=">&lt;Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Lotus 1-2-3</description>
+	<test offset="0" type="belong" comparator="=">0x1a00</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>wk3 document data</description>
+			<test offset="4" type="belong" comparator="=">0x100400</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>wk4 document data</description>
+			<test offset="4" type="belong" comparator="=">0x2100400</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>fm3 or fmb document data</description>
+			<test offset="4" type="belong" comparator="=">0x7800100</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>fm3 or fmb document data</description>
+			<test offset="4" type="belong" comparator="=">0x7800000</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>Lotus 1-2-3</description>
+	<test offset="0" type="belong" comparator="=">0x200</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>wk1 document data</description>
+			<test offset="4" type="belong" comparator="=">0x6040600</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>fmt document data</description>
+			<test offset="4" type="belong" comparator="=">0x6800200</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>WordPerfect document</description>
+	<test offset="1" type="string" comparator="=">WPC</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>MS Windows Help Data</description>
+	<test offset="0" type="string" comparator="=">?_\003\000</test>
+</match>
+<!--<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>"compact bitmap" format (Poskanzer)</description>
+	<test offset="0" type="short" comparator="="></test>
+</match>-->
+<match>
+	<mimetype>application/pdf</mimetype>
+	<extension>pdf</extension>
+	<description>PDF document</description>
+	<test offset="0" type="string" comparator="=">%PDF-</test>
+	<match-list>
+		<match>
+			<mimetype>application/pdf</mimetype>
+			<extension>pdf</extension>
+			<description>version %c</description>
+			<test offset="5" type="byte" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>application/pdf</mimetype>
+			<extension>pdf</extension>
+			<description>\b.%c</description>
+			<test offset="7" type="byte" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>DOS EPS Binary File</description>
+	<test offset="0" type="belong" comparator="=">0xc5d0d3c6</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Postscript starts at byte %d</description>
+			<test offset="4" type="long" comparator="&gt;"></test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>length %d</description>
+					<test offset="8" type="long" comparator="&gt;"></test>
+					<match-list>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>Metafile starts at byte %d</description>
+							<test offset="12" type="long" comparator="&gt;"></test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>length %d</description>
+									<test offset="16" type="long" comparator="&gt;"></test>
+								</match>
+							</match-list>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>TIFF starts at byte %d</description>
+							<test offset="20" type="long" comparator="&gt;"></test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>length %d</description>
+									<test offset="24" type="long" comparator="&gt;"></test>
+								</match>
+							</match-list>
+						</match>
+					</match-list>
+				</match>
+			</match-list>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>PPD file</description>
+	<test offset="0" type="string" comparator="=">*PPD-Adobe:</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>ve</description>
+			<test offset="13" type="string" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>RIFF (little-endian) data</description>
+	<test offset="0" type="string" comparator="=">RIFF</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>palette</description>
+			<test offset="8" type="string" comparator="=">PAL</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>version %d</description>
+					<test offset="16" type="leshort" comparator="="></test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%d entries</description>
+					<test offset="18" type="leshort" comparator="="></test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>device-independent bitmap</description>
+			<test offset="8" type="string" comparator="=">RDIB</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description></description>
+					<test offset="16" type="string" comparator="=">BM</test>
+					<match-list>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>OS/2 1.x format</description>
+							<test offset="30" type="leshort" comparator="=">0xc</test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="34" type="leshort" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d</description>
+									<test offset="36" type="leshort" comparator="="></test>
+								</match>
+							</match-list>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>OS/2 2.x format</description>
+							<test offset="30" type="leshort" comparator="=">0x40</test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="34" type="leshort" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d</description>
+									<test offset="36" type="leshort" comparator="="></test>
+								</match>
+							</match-list>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>Windows 3.x format</description>
+							<test offset="30" type="leshort" comparator="=">0x28</test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="34" type="lelong" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="38" type="lelong" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d</description>
+									<test offset="44" type="leshort" comparator="="></test>
+								</match>
+							</match-list>
+						</match>
+					</match-list>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>MIDI</description>
+			<test offset="8" type="string" comparator="=">RMID</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>multimedia movie</description>
+			<test offset="8" type="string" comparator="=">RMMP</test>
+		</match>
+		<match>
+			<mimetype>application/x-wav</mimetype>
+			<extension>wav</extension>
+			<description>WAVE audio</description>
+			<test offset="8" type="string" comparator="=">WAVE</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>Microsoft PCM</description>
+					<test offset="20" type="leshort" comparator="=">0x1</test>
+					<match-list>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>%d bit</description>
+							<test offset="34" type="leshort" comparator="&gt;">0x0</test>
+						</match>
+					</match-list>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>mono</description>
+					<test offset="22" type="leshort" comparator="=">0x1</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>stereo</description>
+					<test offset="22" type="leshort" comparator="=">0x2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%d channels</description>
+					<test offset="22" type="leshort" comparator="&gt;">0x2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%d Hz</description>
+					<test offset="24" type="lelong" comparator="&gt;">0x0</test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>AVI</description>
+			<test offset="8" type="string" comparator="=">AVI </test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>animated cursor</description>
+			<test offset="8" type="string" comparator="=">ACON</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>RIFF (big-endian) data</description>
+	<test offset="0" type="string" comparator="=">RIFX</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>palette</description>
+			<test offset="8" type="string" comparator="=">PAL</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>version %d</description>
+					<test offset="16" type="beshort" comparator="="></test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%d entries</description>
+					<test offset="18" type="beshort" comparator="="></test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>device-independent bitmap</description>
+			<test offset="8" type="string" comparator="=">RDIB</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description></description>
+					<test offset="16" type="string" comparator="=">BM</test>
+					<match-list>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>OS/2 1.x format</description>
+							<test offset="30" type="beshort" comparator="=">0xc</test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="34" type="beshort" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d</description>
+									<test offset="36" type="beshort" comparator="="></test>
+								</match>
+							</match-list>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>OS/2 2.x format</description>
+							<test offset="30" type="beshort" comparator="=">0x40</test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="34" type="beshort" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d</description>
+									<test offset="36" type="beshort" comparator="="></test>
+								</match>
+							</match-list>
+						</match>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>Windows 3.x format</description>
+							<test offset="30" type="beshort" comparator="=">0x28</test>
+							<match-list>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="34" type="belong" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d x</description>
+									<test offset="38" type="belong" comparator="="></test>
+								</match>
+								<match>
+									<mimetype>???</mimetype>
+									<extension>???</extension>
+									<description>%d</description>
+									<test offset="44" type="beshort" comparator="="></test>
+								</match>
+							</match-list>
+						</match>
+					</match-list>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>MIDI</description>
+			<test offset="8" type="string" comparator="=">RMID</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>multimedia movie</description>
+			<test offset="8" type="string" comparator="=">RMMP</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WAVE audio</description>
+			<test offset="8" type="string" comparator="=">WAVE</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>Microsoft PCM</description>
+					<test offset="20" type="leshort" comparator="=">0x1</test>
+					<match-list>
+						<match>
+							<mimetype>???</mimetype>
+							<extension>???</extension>
+							<description>%d bit</description>
+							<test offset="34" type="leshort" comparator="&gt;">0x0</test>
+						</match>
+					</match-list>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>mono</description>
+					<test offset="22" type="beshort" comparator="=">0x1</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>stereo</description>
+					<test offset="22" type="beshort" comparator="=">0x2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%d channels</description>
+					<test offset="22" type="beshort" comparator="&gt;">0x2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%d Hz</description>
+					<test offset="24" type="belong" comparator="&gt;">0x0</test>
+				</match>
+			</match-list>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>AVI</description>
+			<test offset="8" type="string" comparator="=">AVI </test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>animated cursor</description>
+			<test offset="8" type="string" comparator="=">ACON</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Notation Interchange File Format</description>
+			<test offset="8" type="string" comparator="=">NIFF</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description></description>
+	<test offset="0" type="beshort" comparator="=">0xedab</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>RPM</description>
+			<test offset="2" type="beshort" comparator="=">0xeedb</test>
+			<match-list>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>v%d</description>
+					<test offset="4" type="byte" comparator="="></test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>bin</description>
+					<test offset="6" type="beshort" comparator="=">0x0</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>src</description>
+					<test offset="6" type="beshort" comparator="=">0x1</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>i386</description>
+					<test offset="8" type="beshort" comparator="=">0x1</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>Alpha</description>
+					<test offset="8" type="beshort" comparator="=">0x2</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>Sparc</description>
+					<test offset="8" type="beshort" comparator="=">0x3</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>MIPS</description>
+					<test offset="8" type="beshort" comparator="=">0x4</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>PowerPC</description>
+					<test offset="8" type="beshort" comparator="=">0x5</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>68000</description>
+					<test offset="8" type="beshort" comparator="=">0x6</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>SGI</description>
+					<test offset="8" type="beshort" comparator="=">0x7</test>
+				</match>
+				<match>
+					<mimetype>???</mimetype>
+					<extension>???</extension>
+					<description>%s</description>
+					<test offset="10" type="string" comparator="="></test>
+				</match>
+			</match-list>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>text/rtf</mimetype>
+	<extension>rtf</extension>
+	<description>Rich Text Format data,</description>
+	<test offset="0" type="string" comparator="=">{\rtf</test>
+	<match-list>
+		<match>
+			<mimetype>text/rtf</mimetype>
+			<extension>rtf</extension>
+			<description>version %c,</description>
+			<test offset="5" type="byte" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>text/rtf</mimetype>
+			<extension>rtf</extension>
+			<description>ANSI</description>
+			<test offset="6" type="string" comparator="=">\ansi</test>
+		</match>
+		<match>
+			<mimetype>text/rtf</mimetype>
+			<extension>rtf</extension>
+			<description>Apple Macintosh</description>
+			<test offset="6" type="string" comparator="=">\mac</test>
+		</match>
+		<match>
+			<mimetype>text/rtf</mimetype>
+			<extension>rtf</extension>
+			<description>IBM PC, code page 437</description>
+			<test offset="6" type="string" comparator="=">\pc</test>
+		</match>
+		<match>
+			<mimetype>text/rtf</mimetype>
+			<extension>rtf</extension>
+			<description>IBM PS/2, code page 850</description>
+			<test offset="6" type="string" comparator="=">\pca</test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML document text</description>
+	<test offset="0" type="regex" comparator="=">/^\s*&lt;!DOCTYPE HTML/i</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;HEAD</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;head</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;TITLE</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;title</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;html</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;HTML</test>
+</match>
+<match>
+	<mimetype>text/sgml</mimetype>
+	<extension>sgml</extension>
+	<description>exported SGML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;!DOCTYPE</test>
+</match>
+<match>
+	<mimetype>text/sgml</mimetype>
+	<extension>sgml</extension>
+	<description>exported SGML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;!doctype</test>
+</match>
+<match>
+	<mimetype>text/sgml</mimetype>
+	<extension>sgml</extension>
+	<description>exported SGML subdocument text</description>
+	<test offset="0" type="string" comparator="=">&lt;!SUBDOC</test>
+</match>
+<match>
+	<mimetype>text/sgml</mimetype>
+	<extension>sgml</extension>
+	<description>exported SGML subdocument text</description>
+	<test offset="0" type="string" comparator="=">&lt;!subdoc</test>
+</match>
+<match>
+	<mimetype>text/sgml</mimetype>
+	<extension>sgml</extension>
+	<description>exported SGML document text</description>
+	<test offset="0" type="string" comparator="=">&lt;!--</test>
+</match>
+<match>
+	<mimetype>???</mimetype>
+	<extension>???</extension>
+	<description>(Corel/WP)</description>
+	<test offset="1" type="string" comparator="=">WPC</test>
+	<match-list>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect macro</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect keyboard file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect document</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect dictionary</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect thesaurus</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect block</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect rectangular block</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect column block</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect printer data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect printer data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect driver resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect hyphenation code</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect hyphenation data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect macro resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect hyphenation lex</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect wordlist</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect equation resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect spell rules</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect dictionary rules</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect spell rules (Microlytics)</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect settings file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect 4.2 document</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect dialog file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect button bar</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Shell macro</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Shell definition</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Notebook macro</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Notebook help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Notebook keyboard file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Notebook definition</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Calculator help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Calendar help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Calendar data file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Editor macro</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Editor help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Editor keyboard file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Editor macro resource file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Macro editor macro</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Macro editor help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Macro editor keyboard file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect macro</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect keyboard file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect worksheet</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect printer definition</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect graphic definition</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect temporary printer</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>PlanPerfect macro resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Mail</description>
+			<test offset="8" type="byte" comparator="=">0xb</test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>distribution list</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>out box</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>in box</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>users archived mailbox</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>archived message database</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>archived attachments</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Printer temporary file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Scheduler help file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Scheduler in file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Scheduler out file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise settings file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise directory services</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise settings file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Terminal resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Terminal resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Terminal resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GUI loadable text</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>graphics resource data</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>printer settings file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>port definition file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>print queue parameters</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>compressed file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Network service msg file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Network service msg file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>Async gateway login msg</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise message file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise admin domain database</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise admin host database</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise admin remote host database</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>GroupWise admin ADS deferment data file</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>IntelliTAG (SGML) compiled DTD</description>
+			<test offset="8" type="short" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect graphic image (1.0)</description>
+			<test offset="8" type="long" comparator="="></test>
+		</match>
+		<match>
+			<mimetype>???</mimetype>
+			<extension>???</extension>
+			<description>WordPerfect graphic image (2.0)</description>
+			<test offset="8" type="long" comparator="="></test>
+		</match>
+	</match-list>
+</match>
+<match>
+	<mimetype>text/x-java</mimetype>
+	<extension>java</extension>
+	<description>Java source file</description>
+	<test offset="0" type="regex" comparator="=">/^\s*package/</test>
+</match>
+<match>
+	<mimetype>text/x-perl</mimetype>
+	<extension>pl</extension>
+	<description>Perl source file</description>
+	<test offset="0" type="regex" comparator="=">/^#!\/usr\/bin\/perl/</test>
+</match>
+<match>
+	<mimetype>text/x-c</mimetype>
+	<extension>c</extension>
+	<description>C source file</description>
+	<test offset="0" type="regex" comparator="=">/^#include/m</test>
+</match>
+<match>
+	<mimetype>application/x-sh</mimetype>
+	<extension>sh</extension>
+	<description>sh script</description>
+	<test offset="0" type="regex" comparator="=">/^#!\/bin\/sh/</test>
+</match>
+<match>
+	<mimetype>application/x-bash</mimetype>
+	<extension>sh</extension>
+	<description>bash script</description>
+	<test offset="0" type="regex" comparator="=">/^#!\/bin\/bash/</test>
+</match>
+<match>
+	<mimetype>application/x-csh</mimetype>
+	<extension>sh</extension>
+	<description>csh script</description>
+	<test offset="0" type="regex" comparator="=">/^#!\/bin\/csh/</test>
+</match>
+<match>
+	<mimetype>application/x-ksh</mimetype>
+	<extension>sh</extension>
+	<description>ksh script</description>
+	<test offset="0" type="regex" comparator="=">/^#!\/bin\/ksh/</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML Document</description>
+	<test offset="0" type="regex" comparator="=">/^\s*&lt;!DOCTYPE HTML PUBLIC/</test>
+</match>
+<match>
+	<mimetype>text/html</mimetype>
+	<extension>html</extension>
+	<description>HTML Document</description>
+	<test offset="0" type="regex" comparator="=">/^\s*&lt;html&gt;/</test>
+</match>
+<!-- 
+<match>
+	<mimetype>text/plain</mimetype>
+	<extension>txt</extension>
+	<description>ASCII Text Document</description>
+	<test offset="0" type="regex" comparator="!">/[^[:ascii:][:space:]]/</test>
+</match>
+-->
+<match>
+	<mimetype>text/plain</mimetype>
+	<extension></extension>
+	<description>net.sf.jmimemagic.detectors.TextFileDetector</description>
+	<test type="detector" offset="0" length="" bitmask="" comparator="=">net.sf.jmimemagic.detectors.TextFileDetector</test>
+</match>
+<match>
+	<mimetype>application/vnd.oasis.opendocument.text</mimetype>
+	<extension>odt</extension>
+	<description>Open Document Text</description>
+	<test offset="0" type="string" comparator="=">PK\003\004</test>
+</match>
+</match-list>
+</magic>

--- a/src/test/resources/custom/hello.world
+++ b/src/test/resources/custom/hello.world
@@ -1,0 +1,1 @@
+Hello world !!

--- a/src/test/resources/html/doctype_lower.html
+++ b/src/test/resources/html/doctype_lower.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html>
+	<head></head>
+	<body></body>
+</html>

--- a/src/test/resources/html/doctype_mixed1.html
+++ b/src/test/resources/html/doctype_mixed1.html
@@ -1,0 +1,5 @@
+<!doctype HTML>
+<html>
+	<head></head>
+	<body></body>
+</html>

--- a/src/test/resources/html/doctype_mixed2.html
+++ b/src/test/resources/html/doctype_mixed2.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body></body>
+</html>

--- a/src/test/resources/html/doctype_upper.html
+++ b/src/test/resources/html/doctype_upper.html
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<title>Hello</title>
+	</head>
+	<body>
+	</body>
+</html>

--- a/src/test/resources/html/no_doctype_lower.html
+++ b/src/test/resources/html/no_doctype_lower.html
@@ -1,0 +1,7 @@
+<html>
+	<head>
+		<title>Hello</title>
+	</head>
+	<body>
+	</body>
+</html>

--- a/src/test/resources/html/no_doctype_upper.html
+++ b/src/test/resources/html/no_doctype_upper.html
@@ -1,0 +1,7 @@
+<HTML>
+	<head>
+		<title>Hello</title>
+	</head>
+	<body>
+	</body>
+</HTML>

--- a/src/test/resources/html/no_html_lower.html
+++ b/src/test/resources/html/no_html_lower.html
@@ -1,0 +1,1 @@
+<head><title>Hello</title></head>

--- a/src/test/resources/html/no_html_upper.html
+++ b/src/test/resources/html/no_html_upper.html
@@ -1,0 +1,1 @@
+<HEAD><title>Hello</title></<HEAD>>


### PR DESCRIPTION
Improve detection for HTML (case insensitive) as described in #27 and #8.

Be able to provide custom magic.xml file external to the bundled JAR (#7). I didn't want to rewrite existing code so I made the smallest possible changes.

Do you plan any release ? 

Hope it helps !
