### PR TITLE
Update Apache Commons, Commons Logging and Log4J dependencies

### DIFF
--- a/README
+++ b/README
@@ -23,8 +23,8 @@ Requirements:
   Apache Maven 1.0.2+
   JUnit 3.8.x
   Jakarta ORO 2.0.x
-  Commons Logging 1.0.x
-  Log4j 1.2.x
+  Commons Logging 1.2
+  Log4j 1.x Compatibility API 2.17.2
   Xerces 2.4.0 (optional)
 
 Building:

--- a/pom.xml
+++ b/pom.xml
@@ -274,23 +274,23 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.0.4</version>
+      <version>1.2</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.1</version>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
 
     <!-- common runtime only dependencies -->
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.8</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.17.2</version>
       <scope>runtime</scope>
     </dependency>
 


### PR DESCRIPTION
As per [mvnrepository.com](https://mvnrepository.com/artifact/net.sf.jmimemagic/jmimemagic/0.1.5), jMimeMagic has several vulnerabilities in its dependencies that I've tried to remedy here.